### PR TITLE
[RN-805] refactor(chart): deployment's labels scheme 

### DIFF
--- a/helm/sidecarinjector/templates/_helpers.tpl
+++ b/helm/sidecarinjector/templates/_helpers.tpl
@@ -38,6 +38,9 @@ Common labels
 app.kubernetes.io/name: {{ include "sidecarinjector.name" . }}
 helm.sh/chart: {{ include "sidecarinjector.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/helm/sidecarinjector/templates/deployment.yaml
+++ b/helm/sidecarinjector/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ .Values.appname }}
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sidecarinjector.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -12,8 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.appname }}
-        app.kubernetes.io/instance: {{ .Values.appname }}
+        {{- include "sidecarinjector.labels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/sidecarinjector/values.yaml
+++ b/helm/sidecarinjector/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+customLabels:
+  # foo: bar
+
 replicaCount: 1
 appname: sidecarinjector
 namespace: sidecarinjector


### PR DESCRIPTION
- Deployment's labeling scheme refactor

Tested locally with helm template.

```
helm template . --dry-run=client -s templates/deployment.yaml
---
# Source: sidecarinjector/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: sidecarinjector
  namespace: sidecarinjector
  labels:
    app.kubernetes.io/name: sidecarinjector
    helm.sh/chart: sidecarinjector-0.1.0
    app.kubernetes.io/instance: release-name
    foo: bar
    app.kubernetes.io/version: "1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: sidecarinjector
      app.kubernetes.io/instance: sidecarinjector
  template:
    metadata:
      labels:
        app.kubernetes.io/name: sidecarinjector
        helm.sh/chart: sidecarinjector-0.1.0
        app.kubernetes.io/instance: release-name
        foo: bar
        app.kubernetes.io/version: "1.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      containers:
        - name: sidecarinjector
          image: "mayankkr/sidecarinjector:v1"
          imagePullPolicy: Always
          volumeMounts:
            - mountPath: /etc/webhook/config
              name: webhook-config
            - name: webhook-certs
              mountPath: /etc/webhook/certs
              readOnly: true
          args:
            - /sidecarinjector
            - --port=8443
            - --sidecar-config-file=/etc/webhook/config/sidecarconfig.yaml
            - --mutation-config-file=/etc/webhook/config/mutationconfig.yaml
            - --cert-file-path=/etc/webhook/certs/tls.crt
            - --key-file-path=/etc/webhook/certs/tls.key
          resources:
            {}
      volumes:
        - configMap:
            name: sidecarinjector-webhook-configmap
          name: webhook-config
        - name: webhook-certs
          secret:
            secretName: sidecarinjector-certificate
```