### PR TITLE
feat: chart version bump to 0.2.6

### DIFF
--- a/helm/sidecarinjector/Chart.yaml
+++ b/helm/sidecarinjector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: sidecarinjector
-version: 0.1.0
+version: 0.2.6


### PR DESCRIPTION
This PR reflects the actual chart version present inside ECR.

A helm package was generated from the source and pushed into ECR on version 0.2.6

```
helm push sidecarinjector-0.2.6.tgz oci://557130146574.dkr.ecr.us-east-1.amazonaws.com
Pushed: 557130146574.dkr.ecr.us-east-1.amazonaws.com/sidecarinjector:0.2.6
Digest: sha256:2a953e129abbc2f148ff29f9577a080eea855ee3dccb26924f0b57df7bfa8db8
```